### PR TITLE
feat: Add optional cancellation token for oauth client

### DIFF
--- a/Octokit.AsyncPaginationExtension/Extensions.cs
+++ b/Octokit.AsyncPaginationExtension/Extensions.cs
@@ -43,20 +43,20 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<IssueComment> GetAllForRepositoryAsync(this IIssueCommentsClient t, long repositoryId, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, long, ApiOptions)"/>
+        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, long, ApiOptions)"/>
+        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, int, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, int issueNumber, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(string, string, long, IssueCommentRequest, ApiOptions)"/>
+        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, string owner, string name, long issueNumber, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(owner, name, issueNumber, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, int, IssueCommentRequest, ApiOptions)"/>
-    public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, int issueNumber, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
+        /// <inheritdoc cref="IIssueCommentsClient.GetAllForIssue(long, long, IssueCommentRequest, ApiOptions)"/>
+        public static IPaginatedList<IssueComment> GetAllForIssueAsync(this IIssueCommentsClient t, long repositoryId, long issueNumber, IssueCommentRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueComment>(options => t.GetAllForIssue(repositoryId, issueNumber, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IRepositoryPagesClient.GetAll(string, string, ApiOptions)"/>
@@ -107,24 +107,24 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<Notification> GetAllForRepositoryAsync(this INotificationsClient t, long repositoryId, NotificationsRequest request, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Notification>(options => t.GetAllForRepository(repositoryId, request, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, string owner, string repo, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(owner, repo, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssueTimelineClient.GetAllForIssue(long, long, ApiOptions)"/>
+    public static IPaginatedList<TimelineEventInfo> GetAllForIssueAsync(this IIssueTimelineClient t, long repositoryId, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<TimelineEventInfo>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IMiscellaneousClient.GetAllLicenses(ApiOptions)"/>
     public static IPaginatedList<LicenseMetadata> GetAllLicensesAsync(this IMiscellaneousClient t, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<LicenseMetadata>(t.GetAllLicenses, pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, string owner, string name, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, int, ApiOptions)"/>
-    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssueReactionsClient.GetAll(long, long, ApiOptions)"/>
+    public static IPaginatedList<Reaction> GetAllAsync(this IIssueReactionsClient t, long repositoryId, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IRepositoryDeployKeysClient.GetAll(string, string, ApiOptions)"/>
@@ -395,12 +395,12 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<CheckRunAnnotation> GetAllAnnotationsAsync(this ICheckRunsClient t, long repositoryId, long checkRunId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<CheckRunAnnotation>(options => t.GetAllAnnotations(repositoryId, checkRunId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, string owner, string name, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssuesLabelsClient.GetAllForIssue(long, long, ApiOptions)"/>
+    public static IPaginatedList<Label> GetAllForIssueAsync(this IIssuesLabelsClient t, long repositoryId, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Label>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssuesLabelsClient.GetAllForRepository(string, string, ApiOptions)"/>
@@ -551,12 +551,12 @@ namespace Octokit.AsyncPaginationExtension
     public static IPaginatedList<Reaction> GetAllAsync(this IPullRequestReviewCommentReactionsClient t, long repositoryId, long commentId, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<Reaction>(options => t.GetAll(repositoryId, commentId, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, int, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(string, string, long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, string owner, string name, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(owner, name, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
-    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, int, ApiOptions)"/>
-    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, int issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
+    /// <inheritdoc cref="IIssuesEventsClient.GetAllForIssue(long, long, ApiOptions)"/>
+    public static IPaginatedList<IssueEvent> GetAllForIssueAsync(this IIssuesEventsClient t, long repositoryId, long issueNumber, int pageSize = DEFAULT_PAGE_SIZE)
         => pageSize > 0 ? new PaginatedList<IssueEvent>(options => t.GetAllForIssue(repositoryId, issueNumber, options), pageSize) : throw new ArgumentOutOfRangeException(nameof(pageSize), pageSize, "The page size must be positive.");
 
     /// <inheritdoc cref="IIssuesEventsClient.GetAllForRepository(string, string, ApiOptions)"/>

--- a/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableAssigneesClient.cs
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
-        IObservable<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
+        IObservable<Issue> AddAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Remove assignees from a specified Issue.
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove </param>
         /// <returns></returns>
-        IObservable<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
+        IObservable<Issue> RemoveAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.

--- a/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueCommentsClient.cs
@@ -108,7 +108,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -116,7 +116,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -126,7 +126,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -135,7 +135,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -145,7 +145,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -154,7 +154,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -165,7 +165,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -175,7 +175,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options);
+        IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -185,7 +185,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        IObservable<IssueComment> Create(string owner, string name, int issueNumber, string newComment);
+        IObservable<IssueComment> Create(string owner, string name, long issueNumber, string newComment);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -194,7 +194,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        IObservable<IssueComment> Create(long repositoryId, int issueNumber, string newComment);
+        IObservable<IssueComment> Create(long repositoryId, long issueNumber, string newComment);
 
         /// <summary>
         /// Updates a specified Issue Comment.

--- a/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Reaction> GetAll(string owner, string name, int issueNumber);
+        IObservable<Reaction> GetAll(string owner, string name, long issueNumber);
 
         /// <summary>
         /// List reactions for a specified Issue.
@@ -28,7 +28,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Reaction> GetAll(string owner, string name, int issueNumber, ApiOptions options);
+        IObservable<Reaction> GetAll(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// List reactions for a specified Issue.
@@ -36,7 +36,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Reaction> GetAll(long repositoryId, int issueNumber);
+        IObservable<Reaction> GetAll(long repositoryId, long issueNumber);
 
         /// <summary>
         /// List reactions for a specified Issue.
@@ -45,7 +45,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Reaction> GetAll(long repositoryId, int issueNumber, ApiOptions options);
+        IObservable<Reaction> GetAll(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Creates a reaction for a specified Issue.
@@ -55,7 +55,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create </param>
-        IObservable<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction);
+        IObservable<Reaction> Create(string owner, string name, long issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Creates a reaction for a specified Issue.
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create </param>
-        IObservable<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction);
+        IObservable<Reaction> Create(long repositoryId, long issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue
@@ -75,7 +75,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(string owner, string name, int issueNumber, long reactionId);
+        IObservable<Unit> Delete(string owner, string name, long issueNumber, long reactionId);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue
@@ -85,6 +85,6 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
-        IObservable<Unit> Delete(long repositoryId, int issueNumber, long reactionId);
+        IObservable<Unit> Delete(long repositoryId, long issueNumber, long reactionId);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssueTimelineClient.cs
@@ -19,7 +19,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber);
+        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, long issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options);
+        IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber);
+        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -52,6 +52,6 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesClient.cs
@@ -60,7 +60,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(string owner, string name, int issueNumber);
+        IObservable<Issue> Get(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -72,7 +72,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        IObservable<Issue> Get(long repositoryId, int issueNumber);
+        IObservable<Issue> Get(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -309,7 +309,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(string owner, string name, long issueNumber, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Creates an issue for the specified repository. Any user with pull access to a repository can create an
@@ -320,6 +320,6 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        IObservable<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate);
+        IObservable<Issue> Update(long repositoryId, long issueNumber, IssueUpdate issueUpdate);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesEventsClient.cs
@@ -20,7 +20,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber);
+        IObservable<IssueEvent> GetAllForIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -30,7 +30,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber);
+        IObservable<IssueEvent> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -42,7 +42,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
+        IObservable<IssueEvent> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        IObservable<IssueEvent> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.

--- a/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/IObservableIssuesLabelsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber);
+        IObservable<Label> GetAllForIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber);
+        IObservable<Label> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -43,7 +43,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
+        IObservable<Label> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -54,7 +54,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        IObservable<Label> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -240,7 +240,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        IObservable<Label> AddToIssue(string owner, string name, int issueNumber, string[] labels);
+        IObservable<Label> AddToIssue(string owner, string name, long issueNumber, string[] labels);
 
         /// <summary>
         /// Adds a label to an issue
@@ -251,7 +251,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        IObservable<Label> AddToIssue(long repositoryId, int issueNumber, string[] labels);
+        IObservable<Label> AddToIssue(long repositoryId, long issueNumber, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -263,7 +263,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        IObservable<Label> RemoveFromIssue(string owner, string name, int issueNumber, string labelName);
+        IObservable<Label> RemoveFromIssue(string owner, string name, long issueNumber, string labelName);
 
         /// <summary>
         /// Removes a label from an issue
@@ -274,7 +274,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        IObservable<Label> RemoveFromIssue(long repositoryId, int issueNumber, string labelName);
+        IObservable<Label> RemoveFromIssue(long repositoryId, long issueNumber, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -286,7 +286,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        IObservable<Label> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels);
+        IObservable<Label> ReplaceAllForIssue(string owner, string name, long issueNumber, string[] labels);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -297,7 +297,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        IObservable<Label> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels);
+        IObservable<Label> ReplaceAllForIssue(long repositoryId, long issueNumber, string[] labels);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -308,7 +308,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Unit> RemoveAllFromIssue(string owner, string name, int issueNumber);
+        IObservable<Unit> RemoveAllFromIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -318,6 +318,6 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Unit> RemoveAllFromIssue(long repositoryId, int issueNumber);
+        IObservable<Unit> RemoveAllFromIssue(long repositoryId, long issueNumber);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableLockUnlockClient.cs
+++ b/Octokit.Reactive/Clients/IObservableLockUnlockClient.cs
@@ -16,7 +16,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        IObservable<Unit> Lock(string owner, string name, int issueNumber, LockReason? lockReason = null);
+        IObservable<Unit> Lock(string owner, string name, long issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue.
@@ -25,7 +25,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        IObservable<Unit> Lock(long repositoryId, int issueNumber, LockReason? lockReason = null);
+        IObservable<Unit> Lock(long repositoryId, long issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Unit> Unlock(string owner, string name, int issueNumber);
+        IObservable<Unit> Unlock(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue.
@@ -42,6 +42,6 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        IObservable<Unit> Unlock(long repositoryId, int issueNumber);
+        IObservable<Unit> Unlock(long repositoryId, long issueNumber);
     }
 }

--- a/Octokit.Reactive/Clients/IObservableOauthClient.cs
+++ b/Octokit.Reactive/Clients/IObservableOauthClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 
 namespace Octokit.Reactive
 {
@@ -22,8 +23,9 @@ namespace Octokit.Reactive
         /// an access token using this method.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request);
+        IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Makes a request to initiate the device flow authentication.
@@ -33,25 +35,28 @@ namespace Octokit.Reactive
         /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request);
+        IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
         /// </remarks>
         /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
-        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse);
+        IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest)"/>.
+        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest, CancellationToken)"/>.
         /// </summary>
         /// <param name="request">Token renewal request.</param>
+        /// <param name="cancellationToken"></param>
         /// <returns><see cref="OauthToken"/> with the new token set.</returns>
-        IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request);
+        IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request, CancellationToken cancellationToken = default);
     }
 }

--- a/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableAssigneesClient.cs
@@ -94,7 +94,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
-        public IObservable<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
+        public IObservable<Issue> AddAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -111,7 +111,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove </param>
         /// <returns></returns>
-        public IObservable<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
+        public IObservable<Issue> RemoveAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));

--- a/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueCommentsClient.cs
@@ -172,7 +172,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -186,7 +186,7 @@ namespace Octokit.Reactive
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -199,7 +199,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -215,7 +215,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -230,7 +230,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -246,7 +246,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
 
@@ -262,7 +262,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -281,7 +281,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueComment> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options)
+        public IObservable<IssueComment> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -297,7 +297,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        public IObservable<IssueComment> Create(string owner, string name, int issueNumber, string newComment)
+        public IObservable<IssueComment> Create(string owner, string name, long issueNumber, string newComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -313,7 +313,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The text of the new comment</param>
-        public IObservable<IssueComment> Create(long repositoryId, int issueNumber, string newComment)
+        public IObservable<IssueComment> Create(long repositoryId, long issueNumber, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
 

--- a/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueReactionsClient.cs
@@ -31,7 +31,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Reaction> GetAll(string owner, string name, int issueNumber)
+        public IObservable<Reaction> GetAll(string owner, string name, long issueNumber)
         {
             return GetAll(owner, name, issueNumber, ApiOptions.None);
         }
@@ -44,7 +44,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Reaction> GetAll(string owner, string name, int issueNumber, ApiOptions options)
+        public IObservable<Reaction> GetAll(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -59,7 +59,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Reaction> GetAll(long repositoryId, int issueNumber)
+        public IObservable<Reaction> GetAll(long repositoryId, long issueNumber)
         {
             return GetAll(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -71,7 +71,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Reaction> GetAll(long repositoryId, int issueNumber, ApiOptions options)
+        public IObservable<Reaction> GetAll(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -86,7 +86,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
-        public IObservable<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction)
+        public IObservable<Reaction> Create(string owner, string name, long issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -102,7 +102,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create </param>
-        public IObservable<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction)
+        public IObservable<Reaction> Create(long repositoryId, long issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
 
@@ -118,7 +118,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(string owner, string name, int issueNumber, long reactionId)
+        public IObservable<Unit> Delete(string owner, string name, long issueNumber, long reactionId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -135,7 +135,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
-        public IObservable<Unit> Delete(long repositoryId, int issueNumber, long reactionId)
+        public IObservable<Unit> Delete(long repositoryId, long issueNumber, long reactionId)
         {
             Ensure.ArgumentNotNull(reactionId, nameof(reactionId));
 

--- a/Octokit.Reactive/Clients/ObservableIssueTimelineClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssueTimelineClient.cs
@@ -29,7 +29,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber)
+        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
@@ -47,7 +47,7 @@ namespace Octokit.Reactive
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options)
+        public IObservable<TimelineEventInfo> GetAllForIssue(string owner, string repo, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
@@ -64,7 +64,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber)
+        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -78,7 +78,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public IObservable<TimelineEventInfo> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 

--- a/Octokit.Reactive/Clients/ObservableIssuesClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesClient.cs
@@ -77,7 +77,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Issue> Get(string owner, string name, int issueNumber)
+        public IObservable<Issue> Get(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -93,7 +93,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Issue> Get(long repositoryId, int issueNumber)
+        public IObservable<Issue> Get(long repositoryId, long issueNumber)
         {
             return _client.Get(repositoryId, issueNumber).ToObservable();
         }
@@ -454,7 +454,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(string owner, string name, long issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -472,7 +472,7 @@ namespace Octokit.Reactive
         /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        public IObservable<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate)
+        public IObservable<Issue> Update(long repositoryId, long issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 

--- a/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesEventsClient.cs
@@ -32,7 +32,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber)
+        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -48,7 +48,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber)
+        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -63,7 +63,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -81,7 +81,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public IObservable<IssueEvent> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 

--- a/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
+++ b/Octokit.Reactive/Clients/ObservableIssuesLabelsClient.cs
@@ -34,7 +34,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber)
+        public IObservable<Label> GetAllForIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -50,7 +50,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber)
+        public IObservable<Label> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -65,7 +65,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
+        public IObservable<Label> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -83,7 +83,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        public IObservable<Label> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public IObservable<Label> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -362,7 +362,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        public IObservable<Label> AddToIssue(string owner, string name, int issueNumber, string[] labels)
+        public IObservable<Label> AddToIssue(string owner, string name, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -382,7 +382,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to add</param>
-        public IObservable<Label> AddToIssue(long repositoryId, int issueNumber, string[] labels)
+        public IObservable<Label> AddToIssue(long repositoryId, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
@@ -401,7 +401,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        public IObservable<Label> RemoveFromIssue(string owner, string name, int issueNumber, string labelName)
+        public IObservable<Label> RemoveFromIssue(string owner, string name, long issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -421,7 +421,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label to remove</param>
-        public IObservable<Label> RemoveFromIssue(long repositoryId, int issueNumber, string labelName)
+        public IObservable<Label> RemoveFromIssue(long repositoryId, long issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
 
@@ -440,7 +440,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        public IObservable<Label> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels)
+        public IObservable<Label> ReplaceAllForIssue(string owner, string name, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -460,7 +460,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labels">The names of the labels to set</param>
-        public IObservable<Label> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels)
+        public IObservable<Label> ReplaceAllForIssue(long repositoryId, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
@@ -478,7 +478,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Unit> RemoveAllFromIssue(string owner, string name, int issueNumber)
+        public IObservable<Unit> RemoveAllFromIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -494,7 +494,7 @@ namespace Octokit.Reactive
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Unit> RemoveAllFromIssue(long repositoryId, int issueNumber)
+        public IObservable<Unit> RemoveAllFromIssue(long repositoryId, long issueNumber)
         {
             return _client.RemoveAllFromIssue(repositoryId, issueNumber).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableLockUnlockClient.cs
+++ b/Octokit.Reactive/Clients/ObservableLockUnlockClient.cs
@@ -26,7 +26,7 @@ namespace Octokit.Reactive
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        public IObservable<Unit> Lock(string owner, string name, int issueNumber, LockReason? lockReason = null)
+        public IObservable<Unit> Lock(string owner, string name, long issueNumber, LockReason? lockReason = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -41,7 +41,7 @@ namespace Octokit.Reactive
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        public IObservable<Unit> Lock(long repositoryId, int issueNumber, LockReason? lockReason = null)
+        public IObservable<Unit> Lock(long repositoryId, long issueNumber, LockReason? lockReason = null)
         {
             return _client.Lock(repositoryId, issueNumber, lockReason).ToObservable();
         }
@@ -53,7 +53,7 @@ namespace Octokit.Reactive
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Unit> Unlock(string owner, string name, int issueNumber)
+        public IObservable<Unit> Unlock(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -67,7 +67,7 @@ namespace Octokit.Reactive
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        public IObservable<Unit> Unlock(long repositoryId, int issueNumber)
+        public IObservable<Unit> Unlock(long repositoryId, long issueNumber)
         {
             return _client.Unlock(repositoryId, issueNumber).ToObservable();
         }

--- a/Octokit.Reactive/Clients/ObservableOauthClient.cs
+++ b/Octokit.Reactive/Clients/ObservableOauthClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Reactive.Threading.Tasks;
+using System.Threading;
 
 namespace Octokit.Reactive
 {
@@ -23,24 +24,24 @@ namespace Octokit.Reactive
             return _client.Oauth.GetGitHubLoginUrl(request);
         }
 
-        public IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request)
+        public IObservable<OauthToken> CreateAccessToken(OauthTokenRequest request, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.CreateAccessToken(request).ToObservable();
+            return _client.Oauth.CreateAccessToken(request, cancellationToken).ToObservable();
         }
 
-        public IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request)
+        public IObservable<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.InitiateDeviceFlow(request).ToObservable();
+            return _client.Oauth.InitiateDeviceFlow(request, cancellationToken).ToObservable();
         }
 
-        public IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse)
+        public IObservable<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.CreateAccessTokenForDeviceFlow(clientId, deviceFlowResponse).ToObservable();
+            return _client.Oauth.CreateAccessTokenForDeviceFlow(clientId, deviceFlowResponse, cancellationToken).ToObservable();
         }
 
-        public IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request)
+        public IObservable<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request, CancellationToken cancellationToken = default)
         {
-            return _client.Oauth.CreateAccessTokenFromRenewalToken(request)
+            return _client.Oauth.CreateAccessTokenFromRenewalToken(request, cancellationToken)
                 .ToObservable();
         }
     }

--- a/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
+++ b/Octokit.Tests.Integration/Clients/IssueCommentsClientTests.cs
@@ -260,7 +260,7 @@ public class IssueCommentsClientTests
 
         const string owner = "octokit";
         const string name = "octokit.net";
-        const int issueNumber = 1115;
+        const long issueNumber = 1115;
         const long repositoryId = 7528679;
 
         public TheGetAllForIssueMethod()
@@ -594,7 +594,7 @@ public class IssueCommentsClientTests
         return issue.Number;
     }
 
-    async static Task<long> HelperCreateIssueCommentWithReactions(string owner, string repo, int issueNumber)
+    async static Task<long> HelperCreateIssueCommentWithReactions(string owner, string repo, long issueNumber)
     {
         var github = Helper.GetAuthenticatedClient();
 

--- a/Octokit.Tests/Clients/StatisticsClientTests.cs
+++ b/Octokit.Tests/Clients/StatisticsClientTests.cs
@@ -417,8 +417,8 @@ namespace Octokit.Tests.Clients
                 var expectedEndPoint = new Uri("repos/owner/name/stats/punch_card", UriKind.Relative);
 
                 var client = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
-                client.GetQueuedOperation<int[]>(expectedEndPoint, Args.CancellationToken)
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
+                client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
                     .Returns(Task.FromResult(data));
                 var statisticsClient = new StatisticsClient(client);
 
@@ -436,8 +436,8 @@ namespace Octokit.Tests.Clients
                 var expectedEndPoint = new Uri("repositories/1/stats/punch_card", UriKind.Relative);
 
                 var client = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
-                client.GetQueuedOperation<int[]>(expectedEndPoint, Args.CancellationToken)
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
+                client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
                     .Returns(Task.FromResult(data));
                 var statisticsClient = new StatisticsClient(client);
 
@@ -456,9 +456,9 @@ namespace Octokit.Tests.Clients
                 var cancellationToken = new CancellationToken();
 
                 var connection = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
 
-                connection.GetQueuedOperation<int[]>(expectedEndPoint, cancellationToken)
+                connection.GetQueuedOperation<long[]>(expectedEndPoint, cancellationToken)
                     .Returns(Task.FromResult(data));
                 var client = new StatisticsClient(connection);
 
@@ -477,9 +477,9 @@ namespace Octokit.Tests.Clients
                 var cancellationToken = new CancellationToken();
 
                 var connection = Substitute.For<IApiConnection>();
-                IReadOnlyList<int[]> data = new ReadOnlyCollection<int[]>(new[] { new[] { 2, 8, 42 } });
+                IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new[] { new[] { 2L, 8, 42 } });
 
-                connection.GetQueuedOperation<int[]>(expectedEndPoint, cancellationToken)
+                connection.GetQueuedOperation<long[]>(expectedEndPoint, cancellationToken)
                     .Returns(Task.FromResult(data));
                 var client = new StatisticsClient(connection);
 
@@ -502,6 +502,25 @@ namespace Octokit.Tests.Clients
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetPunchCard("", "name"));
                 await Assert.ThrowsAsync<ArgumentException>(() => client.GetPunchCard("owner", ""));
             }
+        }
+
+        [Fact]
+        public async Task HandlesGreatBigCountsIfGetQueuedOperationTemplateParameterIsLong()
+        {
+            var expectedEndPoint = new Uri("repos/owner/name/stats/punch_card", UriKind.Relative);
+
+            var client = Substitute.For<IApiConnection>();
+            IReadOnlyList<long[]> data = new ReadOnlyCollection<long[]>(new [] { new [] { 2L, 8L, 42424242424242L } });
+            client.GetQueuedOperation<long[]>(expectedEndPoint, Args.CancellationToken)
+                .Returns(Task.FromResult(data));
+            var statisticsClient = new StatisticsClient(client);
+
+            var result = await statisticsClient.GetPunchCard("owner", "name");
+
+            Assert.Single(result.PunchPoints);
+            Assert.Equal(DayOfWeek.Tuesday, result.PunchPoints[0].DayOfWeek);
+            Assert.Equal(8, result.PunchPoints[0].HourOfTheDay);
+            Assert.Equal(42424242424242L, result.PunchPoints[0].CommitCount);
         }
     }
 }

--- a/Octokit.Tests/Models/PunchCardTests.cs
+++ b/Octokit.Tests/Models/PunchCardTests.cs
@@ -33,10 +33,10 @@ public class PunchCardTests
         [Fact]
         public void CanQueryCommitsForDayAndHour()
         {
-            IList<int> point1 = new[] { 1, 0, 3 };
-            IList<int> point2 = new[] { 1, 1, 4 };
-            IList<int> point3 = new[] { 1, 2, 0 };
-            IEnumerable<IList<int>> points = new List<IList<int>> { point1, point2, point3 };
+            IList<long> point1 = new long[] { 1, 0, 3 };
+            IList<long> point2 = new long[] { 1, 1, 4 };
+            IList<long> point3 = new long[] { 1, 2, 0 };
+            IEnumerable<IList<long>> points = new List<IList<long>> { point1, point2, point3 };
 
             var punchCard = new PunchCard(points);
 
@@ -54,10 +54,10 @@ public class PunchCardTests
         [Fact]
         public void SetsPunchPointsAsReadOnlyDictionary()
         {
-            IList<int> point1 = new[] { 1, 0, 3 };
-            IList<int> point2 = new[] { 1, 1, 4 };
-            IList<int> point3 = new[] { 1, 2, 0 };
-            IEnumerable<IList<int>> points = new List<IList<int>> { point1, point2, point3 };
+            IList<long> point1 = new long[] { 1, 0, 3 };
+            IList<long> point2 = new long[] { 1, 1, 4 };
+            IList<long> point3 = new long[] { 1, 2, 0 };
+            IEnumerable<IList<long>> points = new List<IList<long>> { point1, point2, point3 };
 
             var punchCard = new PunchCard(points);
 

--- a/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
+++ b/Octokit.Tests/Reactive/ObservableIssuesClientTests.cs
@@ -722,7 +722,7 @@ public class ObservableIssuesClientTests
         }
     }
 
-    static Issue CreateIssue(int issueNumber)
+    static Issue CreateIssue(long issueNumber)
     {
         var serializer = new SimpleJsonSerializer();
         return serializer.Deserialize<Issue>(@"{""number"": """ + issueNumber + @"""}");

--- a/Octokit.Tests/SimpleJsonTests.cs
+++ b/Octokit.Tests/SimpleJsonTests.cs
@@ -1,0 +1,36 @@
+﻿using Octokit;
+using System.Threading.Tasks;
+using Xunit;
+
+public class SimpleJsonTests
+{
+    [Theory]
+    [InlineData("\"abc\"", "abc")]
+    [InlineData(" \"abc\" ", "abc")]
+    [InlineData("\" abc \" ", " abc ")]
+    [InlineData("\"abc\\\"def\"", "abc\"def")]
+    [InlineData("\"abc\\r\\ndef\"", "abc\r\ndef")]
+    public async Task ParseStringSuccess(string input, string expected)
+    {
+        int index = 0;
+        bool success = true;
+
+        string actual = SimpleJson.ParseString(input.ToCharArray(), ref index, ref success);
+
+        Assert.True(success);
+        Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [InlineData("\"abc")]
+    public async Task ParseStringIncomplete(string input)
+    {
+        int index = 0;
+        bool success = true;
+
+        string actual = SimpleJson.ParseString(input.ToCharArray(), ref index, ref success);
+
+        Assert.False(success);
+        Assert.Null(actual);
+    }
+}

--- a/Octokit/Clients/AssigneesClient.cs
+++ b/Octokit/Clients/AssigneesClient.cs
@@ -109,7 +109,7 @@ namespace Octokit
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{issue_number}/assignees")]
-        public Task<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
+        public Task<Issue> AddAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -127,7 +127,7 @@ namespace Octokit
         /// <param name="assignees">List of assignees to remove</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/assignees")]
-        public Task<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees)
+        public Task<Issue> RemoveAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));

--- a/Octokit/Clients/IAssigneesClient.cs
+++ b/Octokit/Clients/IAssigneesClient.cs
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of names of assignees to add</param>
         /// <returns></returns>
-        Task<Issue> AddAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
+        Task<Issue> AddAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Remove assignees from a specified Issue.
@@ -65,7 +65,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="assignees">List of assignees to remove</param>
         /// <returns></returns>
-        Task<Issue> RemoveAssignees(string owner, string name, int issueNumber, AssigneesUpdate assignees);
+        Task<Issue> RemoveAssignees(string owner, string name, long issueNumber, AssigneesUpdate assignees);
 
         /// <summary>
         /// Checks to see if a user is an assignee for a repository.

--- a/Octokit/Clients/IIssueCommentsClient.cs
+++ b/Octokit/Clients/IIssueCommentsClient.cs
@@ -108,7 +108,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -116,7 +116,7 @@ namespace Octokit
         /// <remarks>http://developer.github.com/v3/issues/comments/#list-comments-on-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -126,7 +126,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -135,7 +135,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -145,7 +145,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -154,7 +154,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -165,7 +165,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Gets Issue Comments for a specified Issue.
@@ -175,7 +175,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options);
+        Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request, ApiOptions options);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -185,7 +185,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        Task<IssueComment> Create(string owner, string name, int issueNumber, string newComment);
+        Task<IssueComment> Create(string owner, string name, long issueNumber, string newComment);
 
         /// <summary>
         /// Creates a new Issue Comment for a specified Issue.
@@ -194,7 +194,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="newComment">The new comment to add to the issue</param>
-        Task<IssueComment> Create(long repositoryId, int issueNumber, string newComment);
+        Task<IssueComment> Create(long repositoryId, long issueNumber, string newComment);
 
         /// <summary>
         /// Updates a specified Issue Comment.

--- a/Octokit/Clients/IIssueReactionsClient.cs
+++ b/Octokit/Clients/IIssueReactionsClient.cs
@@ -18,7 +18,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber);
+        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Get all reactions for a specified Issue
@@ -28,7 +28,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Get all reactions for a specified Issue
@@ -36,7 +36,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/reactions/#list-reactions-for-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Get all reactions for a specified Issue
@@ -45,7 +45,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Creates a reaction for a specified Issue
@@ -55,7 +55,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction);
+        Task<Reaction> Create(string owner, string name, long issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Creates a reaction for a specified Issue
@@ -64,7 +64,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
-        Task<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction);
+        Task<Reaction> Create(long repositoryId, long issueNumber, NewReaction reaction);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue
@@ -75,7 +75,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
-        Task Delete(string owner, string name, int issueNumber, long reactionId);
+        Task Delete(string owner, string name, long issueNumber, long reactionId);
 
         /// <summary>
         /// Deletes a reaction for a specified Issue
@@ -85,6 +85,6 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
-        Task Delete(long repositoryId, int issueNumber, long reactionId);
+        Task Delete(long repositoryId, long issueNumber, long reactionId);
     }
 }

--- a/Octokit/Clients/IIssueTimelineClient.cs
+++ b/Octokit/Clients/IIssueTimelineClient.cs
@@ -20,7 +20,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, long issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -32,7 +32,7 @@ namespace Octokit
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -42,7 +42,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all the various events that have occurred around an issue or pull request.
@@ -53,6 +53,6 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
     }
 }

--- a/Octokit/Clients/IIssuesClient.cs
+++ b/Octokit/Clients/IIssuesClient.cs
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(string owner, string name, int issueNumber);
+        Task<Issue> Get(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets a single Issue by number.
@@ -66,7 +66,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         [SuppressMessage("Microsoft.Naming", "CA1716:IdentifiersShouldNotMatchKeywords", MessageId = "Get",
              Justification = "Method makes a network request")]
-        Task<Issue> Get(long repositoryId, int issueNumber);
+        Task<Issue> Get(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all open issues assigned to the authenticated user across all the authenticated user’s visible
@@ -303,7 +303,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate);
+        Task<Issue> Update(string owner, string name, long issueNumber, IssueUpdate issueUpdate);
 
         /// <summary>
         /// Updates an issue for the specified repository. Any user with pull access to a repository can update an
@@ -314,7 +314,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
-        Task<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate);
+        Task<Issue> Update(long repositoryId, long issueNumber, IssueUpdate issueUpdate);
 
     }
 }

--- a/Octokit/Clients/IIssuesEventsClient.cs
+++ b/Octokit/Clients/IIssuesEventsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int issueNumber);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -43,7 +43,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the issue.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all events for the repository.

--- a/Octokit/Clients/IIssuesLabelsClient.cs
+++ b/Octokit/Clients/IIssuesLabelsClient.cs
@@ -21,7 +21,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber);
+        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -31,7 +31,7 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber);
+        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, long issueNumber);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -43,7 +43,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the issue.
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
-        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options);
+        Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options);
 
         /// <summary>
         /// Gets all  labels for the repository.
@@ -240,7 +240,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int issueNumber, string[] labels);
+        Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, long issueNumber, string[] labels);
 
         /// <summary>
         /// Adds a label to an issue
@@ -251,7 +251,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
-        Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int issueNumber, string[] labels);
+        Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, long issueNumber, string[] labels);
 
         /// <summary>
         /// Removes a label from an issue
@@ -263,7 +263,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int issueNumber, string labelName);
+        Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, long issueNumber, string labelName);
 
         /// <summary>
         /// Removes a label from an issue
@@ -274,7 +274,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
-        Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int issueNumber, string labelName);
+        Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, long issueNumber, string labelName);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -286,7 +286,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels);
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, long issueNumber, string[] labels);
 
         /// <summary>
         /// Replaces all labels on the specified issues with the provided labels
@@ -297,7 +297,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
-        Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels);
+        Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, long issueNumber, string[] labels);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -308,7 +308,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
-        Task RemoveAllFromIssue(string owner, string name, int issueNumber);
+        Task RemoveAllFromIssue(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Removes all labels from an issue
@@ -318,6 +318,6 @@ namespace Octokit
         /// </remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
-        Task RemoveAllFromIssue(long repositoryId, int issueNumber);
+        Task RemoveAllFromIssue(long repositoryId, long issueNumber);
     }
 }

--- a/Octokit/Clients/ILockUnlockClient.cs
+++ b/Octokit/Clients/ILockUnlockClient.cs
@@ -15,7 +15,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        Task Lock(string owner, string name, int issueNumber, LockReason? lockReason = null);
+        Task Lock(string owner, string name, long issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Locks an issue for the specified repository. Issue owners and users with push access can lock an issue or pull request's conversation.
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
-        Task Lock(long repositoryId, int issueNumber, LockReason? lockReason = null);
+        Task Lock(long repositoryId, long issueNumber, LockReason? lockReason = null);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
@@ -33,7 +33,7 @@ namespace Octokit
         /// <param name="owner">The owner of the repository</param>
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task Unlock(string owner, string name, int issueNumber);
+        Task Unlock(string owner, string name, long issueNumber);
 
         /// <summary>
         /// Unlocks an issue for the specified repository. Issue owners and users with push access can unlock an issue or pull request's conversation.
@@ -41,7 +41,7 @@ namespace Octokit
         /// <remarks>https://developer.github.com/v3/issues/#unlock-an-issue</remarks>
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
-        Task Unlock(long repositoryId, int issueNumber);
+        Task Unlock(long repositoryId, long issueNumber);
 
     }
 }

--- a/Octokit/Clients/IOAuthClient.cs
+++ b/Octokit/Clients/IOAuthClient.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Octokit
@@ -26,8 +27,9 @@ namespace Octokit
         /// an access token using this method.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="concellationToken"></param>
         /// <returns></returns>
-        Task<OauthToken> CreateAccessToken(OauthTokenRequest request);
+        Task<OauthToken> CreateAccessToken(OauthTokenRequest request, CancellationToken concellationToken = default);
 
         /// <summary>
         /// Makes a request to initiate the device flow authentication.
@@ -37,25 +39,28 @@ namespace Octokit
         /// This request also returns a device verification code that you must use to receive an access token to check the status of user authentication.
         /// </remarks>
         /// <param name="request"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request);
+        Task<OauthDeviceFlowResponse> InitiateDeviceFlow(OauthDeviceFlowRequest request, CancellationToken cancellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/>.
+        /// Makes a request to get an access token using the response from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/>.
         /// </summary>
         /// <remarks>
         /// Will poll the access token endpoint, until the device and user codes expire or the user has successfully authorized the app with a valid user code.
         /// </remarks>
         /// <param name="clientId">The client Id you received from GitHub when you registered the application.</param>
-        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest)"/></param>
+        /// <param name="deviceFlowResponse">The response you received from <see cref="InitiateDeviceFlow(OauthDeviceFlowRequest, CancellationToken)"/></param>
+        /// <param name="concellationToken"></param>
         /// <returns></returns>
-        Task<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse);
+        Task<OauthToken> CreateAccessTokenForDeviceFlow(string clientId, OauthDeviceFlowResponse deviceFlowResponse, CancellationToken concellationToken = default);
 
         /// <summary>
-        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest)"/>.
+        /// Makes a request to get an access token using the refresh token returned in <see cref="CreateAccessToken(OauthTokenRequest, CancellationToken)"/>.
         /// </summary>
         /// <param name="request">Token renewal request.</param>
+        /// <param name="concellationToken"></param>
         /// <returns><see cref="OauthToken"/> with the new token set.</returns>
-        Task<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request);
+        Task<OauthToken> CreateAccessTokenFromRenewalToken(OauthTokenRenewalRequest request, CancellationToken concellationToken = default);
     }
 }

--- a/Octokit/Clients/IssueCommentsClient.cs
+++ b/Octokit/Clients/IssueCommentsClient.cs
@@ -178,7 +178,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -193,7 +193,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -207,7 +207,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -224,7 +224,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -240,7 +240,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -257,7 +257,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
 
@@ -274,7 +274,7 @@ namespace Octokit
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, int issueNumber, IssueCommentRequest request, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(string owner, string name, long issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -293,7 +293,7 @@ namespace Octokit
         /// <param name="request">The sorting <see cref="IssueCommentRequest">parameters</see></param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, int issueNumber, IssueCommentRequest request, ApiOptions options)
+        public Task<IReadOnlyList<IssueComment>> GetAllForIssue(long repositoryId, long issueNumber, IssueCommentRequest request, ApiOptions options)
         {
             Ensure.ArgumentNotNull(request, nameof(request));
             Ensure.ArgumentNotNull(options, nameof(options));
@@ -310,7 +310,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The new comment to add to the issue</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{number]/comments")]
-        public Task<IssueComment> Create(string owner, string name, int issueNumber, string newComment)
+        public Task<IssueComment> Create(string owner, string name, long issueNumber, string newComment)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -327,7 +327,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="newComment">The new comment to add to the issue</param>
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/comments")]
-        public Task<IssueComment> Create(long repositoryId, int issueNumber, string newComment)
+        public Task<IssueComment> Create(long repositoryId, long issueNumber, string newComment)
         {
             Ensure.ArgumentNotNull(newComment, nameof(newComment));
 

--- a/Octokit/Clients/IssueReactionsClient.cs
+++ b/Octokit/Clients/IssueReactionsClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber)
+        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, long issueNumber)
         {
             return GetAll(owner, name, issueNumber, ApiOptions.None);
         }
@@ -38,7 +38,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<Reaction>> GetAll(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -54,7 +54,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, long issueNumber)
         {
             return GetAll(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -67,7 +67,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/reactions")]
-        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<Reaction>> GetAll(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -83,7 +83,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{issue_number}/reactions")]
-        public Task<Reaction> Create(string owner, string name, int issueNumber, NewReaction reaction)
+        public Task<Reaction> Create(string owner, string name, long issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -100,7 +100,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reaction">The reaction to create</param>
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/reactions")]
-        public Task<Reaction> Create(long repositoryId, int issueNumber, NewReaction reaction)
+        public Task<Reaction> Create(long repositoryId, long issueNumber, NewReaction reaction)
         {
             Ensure.ArgumentNotNull(reaction, nameof(reaction));
 
@@ -117,7 +117,7 @@ namespace Octokit
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/reactions/{reaction_id}")]
-        public Task Delete(string owner, string name, int issueNumber, long reactionId)
+        public Task Delete(string owner, string name, long issueNumber, long reactionId)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -134,7 +134,7 @@ namespace Octokit
         /// <param name="reactionId">The reaction id</param>
         /// <returns></returns>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{issue_number}/reactions/{reaction_id}")]
-        public Task Delete(long repositoryId, int issueNumber, long reactionId)
+        public Task Delete(long repositoryId, long issueNumber, long reactionId)
         {
             return ApiConnection.Delete(ApiUrls.IssueReaction(repositoryId, issueNumber, reactionId));
         }

--- a/Octokit/Clients/IssueTimelineClient.cs
+++ b/Octokit/Clients/IssueTimelineClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
@@ -44,7 +44,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API repsonse</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(string owner, string repo, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(repo, nameof(repo));
@@ -62,7 +62,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -77,7 +77,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/timeline")]
-        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<TimelineEventInfo>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 

--- a/Octokit/Clients/IssuesClient.cs
+++ b/Octokit/Clients/IssuesClient.cs
@@ -73,7 +73,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}")]
-        public Task<Issue> Get(string owner, string name, int issueNumber)
+        public Task<Issue> Get(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -90,7 +90,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}")]
-        public Task<Issue> Get(long repositoryId, int issueNumber)
+        public Task<Issue> Get(long repositoryId, long issueNumber)
         {
             return ApiConnection.Get<Issue>(ApiUrls.Issue(repositoryId, issueNumber), null);
         }
@@ -473,7 +473,7 @@ namespace Octokit
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
         [ManualRoute("PATCH", "/repos/{owner}/{repo}/issues/{issue_number}")]
-        public Task<Issue> Update(string owner, string name, int issueNumber, IssueUpdate issueUpdate)
+        public Task<Issue> Update(string owner, string name, long issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -492,7 +492,7 @@ namespace Octokit
         /// <param name="issueUpdate">An <see cref="IssueUpdate"/> instance describing the changes to make to the issue
         /// </param>
         [ManualRoute("PATCH", "/repositories/{id}/issues/{number}")]
-        public Task<Issue> Update(long repositoryId, int issueNumber, IssueUpdate issueUpdate)
+        public Task<Issue> Update(long repositoryId, long issueNumber, IssueUpdate issueUpdate)
         {
             Ensure.ArgumentNotNull(issueUpdate, nameof(issueUpdate));
 

--- a/Octokit/Clients/IssuesEventsClient.cs
+++ b/Octokit/Clients/IssuesEventsClient.cs
@@ -25,7 +25,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/events")]
-        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -42,7 +42,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/events")]
-        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int issueNumber)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -58,7 +58,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/events")]
-        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -77,7 +77,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/events")]
-        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<IssueEvent>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 

--- a/Octokit/Clients/IssuesLabelsClient.cs
+++ b/Octokit/Clients/IssuesLabelsClient.cs
@@ -26,7 +26,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -43,7 +43,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, long issueNumber)
         {
             return GetAllForIssue(repositoryId, issueNumber, ApiOptions.None);
         }
@@ -59,7 +59,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(string owner, string name, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -78,7 +78,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="options">Options for changing the API response</param>
         [ManualRoute("GET", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, int issueNumber, ApiOptions options)
+        public Task<IReadOnlyList<Label>> GetAllForIssue(long repositoryId, long issueNumber, ApiOptions options)
         {
             Ensure.ArgumentNotNull(options, nameof(options));
 
@@ -378,7 +378,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
         [ManualRoute("POST", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, int issueNumber, string[] labels)
+        public Task<IReadOnlyList<Label>> AddToIssue(string owner, string name, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -397,7 +397,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to add</param>
         [ManualRoute("POST", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, int issueNumber, string[] labels)
+        public Task<IReadOnlyList<Label>> AddToIssue(long repositoryId, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
@@ -415,7 +415,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, int issueNumber, string labelName)
+        public Task<IReadOnlyList<Label>> RemoveFromIssue(string owner, string name, long issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -434,7 +434,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labelName">The name of the label to remove</param>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, int issueNumber, string labelName)
+        public Task<IReadOnlyList<Label>> RemoveFromIssue(long repositoryId, long issueNumber, string labelName)
         {
             Ensure.ArgumentNotNullOrEmptyString(labelName, nameof(labelName));
 
@@ -452,7 +452,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
         [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, int issueNumber, string[] labels)
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(string owner, string name, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -471,7 +471,7 @@ namespace Octokit
         /// <param name="issueNumber">The number of the issue</param>
         /// <param name="labels">The names of the labels to set</param>
         [ManualRoute("PUT", "/repositories/{id}/issues/{number}/labels")]
-        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, int issueNumber, string[] labels)
+        public Task<IReadOnlyList<Label>> ReplaceAllForIssue(long repositoryId, long issueNumber, string[] labels)
         {
             Ensure.ArgumentNotNull(labels, nameof(labels));
 
@@ -488,7 +488,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/labels")]
-        public Task RemoveAllFromIssue(string owner, string name, int issueNumber)
+        public Task RemoveAllFromIssue(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -505,7 +505,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The number of the issue</param>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/labels")]
-        public Task RemoveAllFromIssue(long repositoryId, int issueNumber)
+        public Task RemoveAllFromIssue(long repositoryId, long issueNumber)
         {
             return ApiConnection.Delete(ApiUrls.IssueLabels(repositoryId, issueNumber));
         }

--- a/Octokit/Clients/LockUnlockClient.cs
+++ b/Octokit/Clients/LockUnlockClient.cs
@@ -24,7 +24,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
         [ManualRoute("PUT", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
-        public Task Lock(string owner, string name, int issueNumber, LockReason? lockReason = null)
+        public Task Lock(string owner, string name, long issueNumber, LockReason? lockReason = null)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -40,7 +40,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="lockReason">The reason for locking the issue</param>
         [ManualRoute("PUT", "/repositories/{id}/issues/{number}/lock")]
-        public Task Lock(long repositoryId, int issueNumber, LockReason? lockReason = null)
+        public Task Lock(long repositoryId, long issueNumber, LockReason? lockReason = null)
         {
             return ApiConnection.Put<Issue>(ApiUrls.IssueLock(repositoryId, issueNumber), lockReason.HasValue ? new { LockReaons = lockReason } : new object());
         }
@@ -53,7 +53,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("DELETE", "/repos/{owner}/{repo}/issues/{issue_number}/lock")]
-        public Task Unlock(string owner, string name, int issueNumber)
+        public Task Unlock(string owner, string name, long issueNumber)
         {
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
@@ -68,7 +68,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         [ManualRoute("DELETE", "/repositories/{id}/issues/{number}/lock")]
-        public Task Unlock(long repositoryId, int issueNumber)
+        public Task Unlock(long repositoryId, long issueNumber)
         {
             return ApiConnection.Delete(ApiUrls.IssueLock(repositoryId, issueNumber));
         }

--- a/Octokit/Clients/StatisticsClient.cs
+++ b/Octokit/Clients/StatisticsClient.cs
@@ -265,7 +265,7 @@ namespace Octokit
             Ensure.ArgumentNotNullOrEmptyString(owner, nameof(owner));
             Ensure.ArgumentNotNullOrEmptyString(name, nameof(name));
 
-            var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(ApiUrls.StatsPunchCard(owner, name), cancellationToken).ConfigureAwait(false);
+            var punchCardData = await ApiConnection.GetQueuedOperation<long[]>(ApiUrls.StatsPunchCard(owner, name), cancellationToken).ConfigureAwait(false);
             return new PunchCard(punchCardData);
         }
 
@@ -277,7 +277,7 @@ namespace Octokit
         [ManualRoute("GET", "/repositories/{id}/stats/punch_card")]
         public async Task<PunchCard> GetPunchCard(long repositoryId, CancellationToken cancellationToken)
         {
-            var punchCardData = await ApiConnection.GetQueuedOperation<int[]>(ApiUrls.StatsPunchCard(repositoryId), cancellationToken).ConfigureAwait(false);
+            var punchCardData = await ApiConnection.GetQueuedOperation<long[]>(ApiUrls.StatsPunchCard(repositoryId), cancellationToken).ConfigureAwait(false);
             return new PunchCard(punchCardData);
         }
     }

--- a/Octokit/Helpers/ApiUrls.cs
+++ b/Octokit/Helpers/ApiUrls.cs
@@ -561,7 +561,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri Issue(string owner, string name, int issueNumber)
+        public static Uri Issue(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}".FormatUri(owner, name, issueNumber);
         }
@@ -573,7 +573,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueLock(string owner, string name, int issueNumber)
+        public static Uri IssueLock(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/lock".FormatUri(owner, name, issueNumber);
         }
@@ -585,7 +585,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueReactions(string owner, string name, int issueNumber)
+        public static Uri IssueReactions(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/reactions".FormatUri(owner, name, issueNumber);
         }
@@ -596,7 +596,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueReactions(long repositoryId, int issueNumber)
+        public static Uri IssueReactions(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}/reactions".FormatUri(repositoryId, issueNumber);
         }
@@ -609,7 +609,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reactionid for the issue</param>
         /// <returns></returns>
-        public static Uri IssueReaction(string owner, string name, int issueNumber, long reactionId)
+        public static Uri IssueReaction(string owner, string name, long issueNumber, long reactionId)
         {
             return "repos/{0}/{1}/issues/{2}/reactions/{3}".FormatUri(owner, name, issueNumber, reactionId);
         }
@@ -621,7 +621,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="reactionId">The reactionid for the issue</param>
         /// <returns></returns>
-        public static Uri IssueReaction(long repositoryId, int issueNumber, long reactionId)
+        public static Uri IssueReaction(long repositoryId, long issueNumber, long reactionId)
         {
             return "repositories/{0}/issues/{1}/reactions/{2}".FormatUri(repositoryId, issueNumber, reactionId);
         }
@@ -633,7 +633,7 @@ namespace Octokit
         /// <param name="repo">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueTimeline(string owner, string repo, int issueNumber)
+        public static Uri IssueTimeline(string owner, string repo, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/timeline".FormatUri(owner, repo, issueNumber);
         }
@@ -644,7 +644,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueTimeline(long repositoryId, int issueNumber)
+        public static Uri IssueTimeline(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}/timeline".FormatUri(repositoryId, issueNumber);
         }
@@ -667,7 +667,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueComments(string owner, string name, int issueNumber)
+        public static Uri IssueComments(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/comments".FormatUri(owner, name, issueNumber);
         }
@@ -846,7 +846,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueAssignees(string owner, string name, int issueNumber)
+        public static Uri IssueAssignees(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/assignees".FormatUri(owner, name, issueNumber);
         }
@@ -1052,7 +1052,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssuesEvents(string owner, string name, int issueNumber)
+        public static Uri IssuesEvents(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/events".FormatUri(owner, name, issueNumber);
         }
@@ -1134,7 +1134,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label</param>
         /// <returns></returns>
-        public static Uri IssueLabel(string owner, string name, int issueNumber, string labelName)
+        public static Uri IssueLabel(string owner, string name, long issueNumber, string labelName)
         {
             return "repos/{0}/{1}/issues/{2}/labels/{3}".FormatUri(owner, name, issueNumber, labelName);
         }
@@ -1146,7 +1146,7 @@ namespace Octokit
         /// <param name="name">The name of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns></returns>
-        public static Uri IssueLabels(string owner, string name, int issueNumber)
+        public static Uri IssueLabels(string owner, string name, long issueNumber)
         {
             return "repos/{0}/{1}/issues/{2}/labels".FormatUri(owner, name, issueNumber);
         }
@@ -3402,7 +3402,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue.</returns>
-        public static Uri Issue(long repositoryId, int issueNumber)
+        public static Uri Issue(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}".FormatUri(repositoryId, issueNumber);
         }
@@ -3434,7 +3434,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the comments of a specified issue.</returns>
-        public static Uri IssueComments(long repositoryId, int issueNumber)
+        public static Uri IssueComments(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}/comments".FormatUri(repositoryId, issueNumber);
         }
@@ -3446,7 +3446,7 @@ namespace Octokit
         /// <param name="issueNumber">The issue number</param>
         /// <param name="labelName">The name of the label</param>
         /// <returns>The <see cref="Uri"/> that returns the named label for the specified issue.</returns>
-        public static Uri IssueLabel(long repositoryId, int issueNumber, string labelName)
+        public static Uri IssueLabel(long repositoryId, long issueNumber, string labelName)
         {
             return "repositories/{0}/issues/{1}/labels/{2}".FormatUri(repositoryId, issueNumber, labelName);
         }
@@ -3457,7 +3457,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns all of the labels for the specified issue.</returns>
-        public static Uri IssueLabels(long repositoryId, int issueNumber)
+        public static Uri IssueLabels(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}/labels".FormatUri(repositoryId, issueNumber);
         }
@@ -3468,7 +3468,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> for the specified issue to be locked/unlocked.</returns>
-        public static Uri IssueLock(long repositoryId, int issueNumber)
+        public static Uri IssueLock(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}/lock".FormatUri(repositoryId, issueNumber);
         }
@@ -3500,7 +3500,7 @@ namespace Octokit
         /// <param name="repositoryId">The Id of the repository</param>
         /// <param name="issueNumber">The issue number</param>
         /// <returns>The <see cref="Uri"/> that returns the issue/pull request event info for the specified issue.</returns>
-        public static Uri IssuesEvents(long repositoryId, int issueNumber)
+        public static Uri IssuesEvents(long repositoryId, long issueNumber)
         {
             return "repositories/{0}/issues/{1}/events".FormatUri(repositoryId, issueNumber);
         }

--- a/Octokit/Models/Request/NewTreeItem.cs
+++ b/Octokit/Models/Request/NewTreeItem.cs
@@ -1,6 +1,7 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using Octokit.Internal;
 
 namespace Octokit
 {
@@ -16,9 +17,9 @@ namespace Octokit
         public string Path { get; set; }
 
         /// <summary>
-        /// String of the file mode - one of 100644 for file (blob), 
-        /// 100755 for executable (blob), 040000 for subdirectory (tree), 
-        /// 160000 for submodule (commit) or 
+        /// String of the file mode - one of 100644 for file (blob),
+        /// 100755 for executable (blob), 040000 for subdirectory (tree),
+        /// 160000 for submodule (commit) or
         /// 120000 for a blob that specifies the path of a symlink
         /// </summary>
         public string Mode { get; set; }
@@ -31,11 +32,12 @@ namespace Octokit
 
         /// <summary>
         /// The SHA for this Tree item.
+        /// If both this and Content is null it will delete the item.
         /// </summary>
-        public string Sha { get; set; }
+        [SerializeNull] public string Sha { get; set; }
 
         /// <summary>
-        /// Gets or sets the content you want this file to have. GitHub will write this blob out and use that SHA 
+        /// Gets or sets the content you want this file to have. GitHub will write this blob out and use that SHA
         /// for this entry. Use either this, or tree.sha.
         /// </summary>
         /// <value>

--- a/Octokit/Models/Response/PunchCard.cs
+++ b/Octokit/Models/Response/PunchCard.cs
@@ -19,6 +19,13 @@ namespace Octokit
             punchCardData.Select(point => new PunchCardPoint(point)).ToList());
         }
 
+        public PunchCard(IEnumerable<IList<long>> punchCardData)
+        {
+            Ensure.ArgumentNotNull(punchCardData, nameof(punchCardData));
+            PunchPoints = new ReadOnlyCollection<PunchCardPoint>(
+            punchCardData.Select(point => new PunchCardPoint(point)).ToList());
+        }
+
         public PunchCard(IEnumerable<PunchCardPoint> punchPoints)
         {
             PunchPoints = punchPoints?.ToList();
@@ -36,7 +43,7 @@ namespace Octokit
         /// <param name="dayOfWeek">The day of the week to query</param>
         /// <param name="hourOfDay">The hour in 24 hour time. 0-23.</param>
         /// <returns>The total number of commits made.</returns>
-        public int GetCommitCountFor(DayOfWeek dayOfWeek, int hourOfDay)
+        public long GetCommitCountFor(DayOfWeek dayOfWeek, int hourOfDay)
         {
             var punchPoint = PunchPoints.SingleOrDefault(point => point.DayOfWeek == dayOfWeek && point.HourOfTheDay == hourOfDay);
             return punchPoint == null ? 0 : punchPoint.CommitCount;

--- a/Octokit/Models/Response/PunchCardPoint.cs
+++ b/Octokit/Models/Response/PunchCardPoint.cs
@@ -22,6 +22,18 @@ namespace Octokit
             CommitCount = punchPoint[2];
         }
 
+        public PunchCardPoint(IList<long> punchPoint)
+        {
+            Ensure.ArgumentNotNull(punchPoint, nameof(punchPoint));
+            if (punchPoint.Count != 3)
+            {
+                throw new ArgumentException("Daily punch card must only contain three data points.");
+            }
+            DayOfWeek = (DayOfWeek)punchPoint[0];
+            HourOfTheDay = (int)punchPoint[1];
+            CommitCount = punchPoint[2];
+        }
+
         public PunchCardPoint(DayOfWeek dayOfWeek, int hourOfTheDay, int commitCount)
         {
             DayOfWeek = dayOfWeek;
@@ -31,7 +43,7 @@ namespace Octokit
 
         public StringEnum<DayOfWeek> DayOfWeek { get; private set; }
         public int HourOfTheDay { get; private set; }
-        public int CommitCount { get; private set; }
+        public long CommitCount { get; private set; }
 
         internal string DebuggerDisplay
         {


### PR DESCRIPTION

Noticed this allocation while looking at a profile of solution load in visual studio. These StringBuilder allocations were showing up as 0.5% of total allocations. I took a peek at the code, and reaslized the StringBuilder need not be created unless there is a '\' in the string value being parsed. In that case, just copy already seen characters into a StringBuilder and continue as previously.

Co-authored-by: Nick Floyd <139819+nickfloyd@users.noreply.github.com><!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

*

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

*

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----
